### PR TITLE
Avoid using getFirestore function

### DIFF
--- a/lib/firebase.js
+++ b/lib/firebase.js
@@ -70,7 +70,7 @@ export async function getUserWithUsername(username) {
   // const query = usersRef.where('username', '==', username).limit(1);
 
   const q = query(
-    collection(getFirestore(), 'users'), 
+    collection(firestore, 'users'), 
     where('username', '==', username),
     limit(1)
   )


### PR DESCRIPTION
https://github.com/fireship-io/next-firebase-course/blob/96c177d53921570e16a039e483a4fcc279fb2375/lib/firebase.js#L73

Prefers using `firestore` variable directly instead of using `getFirestore` function which may result in inconsistant behaviour (if another firebase app is added).